### PR TITLE
Bump otel version to 1.13.1*. Fix compilation errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,12 +54,9 @@ lazy val core = (project in file("core"))
     name := "mesmer-akka-core",
     libraryDependencies ++= {
       akka ++
-      openTelemetryApi ++
-      openTelemetryApiMetrics ++
       openTelemetryInstrumentation ++
       scalatest ++
-      akkaTestkit ++
-      openTelemetryInstrumentationApi
+      akkaTestkit
     }
   )
 
@@ -73,7 +70,6 @@ lazy val extension = (project in file("extension"))
     libraryDependencies ++= {
       akka ++
       openTelemetryApi ++
-      openTelemetryApiMetrics ++
       akkaTestkit ++
       scalatest ++
       akkaMultiNodeTestKit ++
@@ -86,7 +82,7 @@ lazy val otelExtension = (project in file("otel-extension"))
   .settings(
     name := "mesmer-otel-extension",
     libraryDependencies ++= {
-      openTelemetryInstrumentation.map(_ % "provided") ++
+      openTelemetryExtension.map(_ % "provided") ++
       openTelemetryMuzzle.map(_ % "provided") ++
       byteBuddy.map(_ % "provided") ++
       akkaTestkit ++
@@ -186,9 +182,8 @@ def runExampleWithOtelAgent = Command.command("runExampleWithOtelAgent") { state
   val newState = extracted.appendWithSession(
     Seq(
       run / javaOptions ++= Seq(
-        s"-javaagent:$root/opentelemetry-javaagent110.jar",
+        s"-javaagent:$root/opentelemetry-javaagent-1.13.1.jar",
         s"-Dotel.service.name=mesmer-example",
-        s"-Dotel.metrics.exporter=otlp",
         s"-Dotel.metric.export.interval=5000",
         s"-Dotel.javaagent.extensions=${(otelExtension / assembly).value.absolutePath}"
       )
@@ -207,9 +202,8 @@ def runStreamExampleWithOtelAgent = Command.command("runStreamExampleWithOtelAge
   val newState = extracted.appendWithSession(
     Seq(
       run / javaOptions ++= Seq(
-        s"-javaagent:$root/opentelemetry-javaagent110.jar",
+        s"-javaagent:$root/opentelemetry-javaagent-1.13.1.jar",
         s"-Dotel.service.name=mesmer-stream-example",
-        s"-Dotel.metrics.exporter=otlp",
         s"-Dotel.metric.export.interval=5000",
         s"-Dotel.javaagent.extensions=${(otelExtension / assembly).value.absolutePath}"
       )

--- a/otel-extension/src/main/scala/akka/ConnectionOtelOps.scala
+++ b/otel-extension/src/main/scala/akka/ConnectionOtelOps.scala
@@ -6,17 +6,21 @@ import akka.stream.impl.fusing.GraphInterpreter.Connection
 
 object ConnectionOtelOps {
 
-  def incrementPushCounter(connection: Connection): Unit =
-    VirtualField
+  def incrementPushCounter(connection: Connection): Unit = {
+    val counters: ConnectionCounters = VirtualField
       .find(classOf[Connection], classOf[ConnectionCounters])
       .get(connection)
-      .incrementPush
 
-  def incrementPullCounter(connection: Connection): Unit =
-    VirtualField
+    counters.incrementPush
+  }
+
+  def incrementPullCounter(connection: Connection): Unit = {
+    val counters: ConnectionCounters = VirtualField
       .find(classOf[Connection], classOf[ConnectionCounters])
       .get(connection)
-      .incrementPull
+
+    counters.incrementPull
+  }
 
   /**
    * Use method handles to extract values stored in synthetic fields
@@ -24,10 +28,12 @@ object ConnectionOtelOps {
    * @return
    *   respectively push and pull counter values
    */
-  def getCounterValues(connection: Connection): (Long, Long) =
-    VirtualField
+  def getCounterValues(connection: Connection): (Long, Long) = {
+    val counters: ConnectionCounters = VirtualField
       .find(classOf[Connection], classOf[ConnectionCounters])
       .get(connection)
-      .getCounters
+
+    counters.getCounters
+  }
 
 }

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/AkkaMailboxInstrumentations.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/AkkaMailboxInstrumentations.scala
@@ -58,10 +58,12 @@ object BoundedNodeMessageQueueAdvice {
 object AbstractBoundedNodeQueueAdvice {
 
   @OnMethodExit
-  def add(@Return result: Boolean, @Advice.This self: Object): Unit =
-    VirtualField
+  def add(@Return result: Boolean, @Advice.This self: Object): Unit = {
+    val field: VirtualField[AbstractBoundedNodeQueue[_], JBoolean] = VirtualField
       .find(classOf[AbstractBoundedNodeQueue[_]], classOf[JBoolean])
-      .set(self.asInstanceOf[AbstractBoundedNodeQueue[_]], result)
+
+    field.set(self.asInstanceOf[AbstractBoundedNodeQueue[_]], result)
+  }
 
 }
 

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/EnvelopeDecorator.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/EnvelopeDecorator.scala
@@ -8,8 +8,10 @@ import io.scalac.mesmer.core.util.Timestamp
 
 object EnvelopeDecorator {
 
-  @inline def getInterval(envelope: Envelope): Interval =
-    VirtualField.find(classOf[Envelope], classOf[Timestamp]).get(envelope).interval()
+  @inline def getInterval(envelope: Envelope): Interval = {
+    val timestamp: Timestamp = VirtualField.find(classOf[Envelope], classOf[Timestamp]).get(envelope)
+    timestamp.interval()
+  }
 
   @inline def setCurrentTimestamp(envelope: Envelope): Unit =
     VirtualField.find(classOf[Envelope], classOf[Timestamp]).set(envelope, Timestamp.create())

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,19 +2,19 @@ import sbt._
 
 object Dependencies {
 
-  val AirframeVersion                = "22.4.2"
-  val AkkaHttpVersion                = "10.2.9"
-  val AkkaManagementVersion          = "1.1.3"
-  val AkkaVersion                    = "2.6.19"
-  val CirceVersion                   = "0.14.1"
-  val GoogleAutoServiceVersion       = "1.0.1"
-  val LogbackVersion                 = "1.2.11"
-  val OpentelemetryVersion           = "1.10.0"
-  val OpentelemetryAlphaVersion      = "1.10.0-alpha"
-  val OpentelemetryMetricsApiVersion = "1.10.0-alpha-rc.1"
-  val PostgresVersion                = "42.3.4"
-  val ScalatestVersion               = "3.2.11"
-  val SlickVersion                   = "3.3.3"
+  val AirframeVersion              = "22.4.2"
+  val AkkaHttpVersion              = "10.2.9"
+  val AkkaManagementVersion        = "1.1.3"
+  val AkkaVersion                  = "2.6.19"
+  val CirceVersion                 = "0.14.1"
+  val GoogleAutoServiceVersion     = "1.0.1"
+  val LogbackVersion               = "1.2.11"
+  val OpentelemetryVersion         = "1.13.0"
+  val OpentelemetryAlphaVersion131 = "1.13.1-alpha"
+  val OpentelemetryAlphaVersion130 = "1.13.0-alpha"
+  val PostgresVersion              = "42.3.4"
+  val ScalatestVersion             = "3.2.11"
+  val SlickVersion                 = "3.3.3"
 
   val akka = Seq(
     "com.typesafe.akka" %% "akka-http"                   % AkkaHttpVersion,
@@ -45,21 +45,17 @@ object Dependencies {
     "io.opentelemetry" % "opentelemetry-api" % OpentelemetryVersion
   )
 
-  val openTelemetryApiMetrics = Seq(
-    "io.opentelemetry" % "opentelemetry-api-metrics" % OpentelemetryMetricsApiVersion
-  )
-
-  val openTelemetryInstrumentationApi = Seq(
-    "io.opentelemetry.javaagent" % "opentelemetry-javaagent-instrumentation-api" % OpentelemetryAlphaVersion
-  )
-
   val openTelemetryInstrumentation = Seq(
+    "io.opentelemetry.javaagent" % "opentelemetry-javaagent-instrumentation-api" % OpentelemetryAlphaVersion131
+  )
+
+  val openTelemetryExtension = Seq(
     "com.google.auto.service"    % "auto-service"                          % GoogleAutoServiceVersion,
-    "io.opentelemetry.javaagent" % "opentelemetry-javaagent-extension-api" % OpentelemetryAlphaVersion
+    "io.opentelemetry.javaagent" % "opentelemetry-javaagent-extension-api" % OpentelemetryAlphaVersion131
   )
 
   val openTelemetryMuzzle = Seq(
-    "io.opentelemetry.javaagent" % "opentelemetry-muzzle" % OpentelemetryAlphaVersion
+    "io.opentelemetry.javaagent" % "opentelemetry-muzzle" % OpentelemetryAlphaVersion131
   )
   val akkaTestkit = Seq(
     "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion     % Test,
@@ -84,9 +80,7 @@ object Dependencies {
     "com.lightbend.akka.management" %% "akka-management"                           % AkkaManagementVersion,
     "com.lightbend.akka.management" %% "akka-management-cluster-http"              % AkkaManagementVersion,
     "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap"         % AkkaManagementVersion,
-    "io.opentelemetry"               % "opentelemetry-exporter-otlp-metrics"       % OpentelemetryAlphaVersion,
-    "io.opentelemetry"               % "opentelemetry-sdk-extension-autoconfigure" % OpentelemetryAlphaVersion,
-    "io.opentelemetry"               % "opentelemetry-sdk"                         % OpentelemetryVersion,
+    "io.opentelemetry"               % "opentelemetry-sdk-extension-autoconfigure" % OpentelemetryAlphaVersion130,
     "io.grpc"                        % "grpc-netty-shaded"                         % "1.45.1",
     "org.wvlet.airframe"            %% "airframe-log"                              % AirframeVersion
   )


### PR DESCRIPTION
*1.13.0 for sdk-autoconfigure - that's the latest for this one.

Closes #394 
___

## Summary:

- bumps to latest version
- removes unnecessary dependencies 
- removes unnecessary configuration (-Dotel.metric.exporter is now otlp by default)
- fixes compilation errors


