### PR TITLE
Update baseUrl of the documentation site

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,8 +8,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Mesmer',
   tagline: 'OpenTelemetry Agent extension for Scala applications',
-  url: 'https://scalaconsultants.github.io/mesmer/',
-  baseUrl: '/mesmer/',
+  url: 'https://mesmer.io/',
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION

## Summary:

Base url needs to change when migrating to mesmer.io domain

