### PR TITLE
Fix/separate extension

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies._
+import sbtassembly.AssemblyOption
 
 lazy val scala213 = "2.13"
 
@@ -56,8 +57,8 @@ lazy val core = (project in file("core"))
   .settings(
     name := "mesmer-akka-core",
     libraryDependencies ++= {
-      akka ++
-      openTelemetryInstrumentation ++
+      akka.map(_ % "provided") ++
+      openTelemetryInstrumentation.map(_ % "provided") ++
       scalatest.map(_ % "test") ++
       akkaTestkit.map(_ % "test")
     }
@@ -89,10 +90,11 @@ lazy val otelExtension = (project in file("otel-extension"))
     excludeDependencies += "io.opentelemetry.javaagent" % "opentelemetry-javaagent-bootstrap",
     libraryDependencies ++= {
       zio.map(_ % "provided") ++
+      akka.map(_ % "provided") ++
       openTelemetryExtension.map(_ % "provided") ++
       openTelemetryMuzzle.map(_ % "provided") ++
       openTelemetryInstrumentation.map(_ % "provided") ++
-      openTelemetryInstrumentationApiSemanticConventions ++
+      openTelemetryInstrumentationApiSemanticConventions.map(_ % "provided") ++
       byteBuddy.map(_ % "provided") ++
       akkaTestkit.map(_ % "it,test") ++
       scalatest.map(_ % "it,test") ++
@@ -101,6 +103,7 @@ lazy val otelExtension = (project in file("otel-extension"))
     assembly / test            := {},
     assembly / assemblyJarName := s"${name.value}_${scalaBinaryVersion.value}-${version.value}-assembly.jar",
     assemblyMergeStrategySettings,
+    assembly / assemblyOption ~= { _.withIncludeScala(false) },
     assembly / artifact := {
       val art = (assembly / artifact).value
       art.withClassifier(Some("assembly"))
@@ -137,7 +140,7 @@ lazy val otelExtension = (project in file("otel-extension"))
       "-Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.io.grpc.Context=INFO"
     )
   )
-  .dependsOn(core % "provided->compile;test->test;compile->compile;it->test")
+  .dependsOn(core % "provided->provided;test->test;compile->compile;it->test")
 
 lazy val example = (project in file("example"))
   .enablePlugins(JavaAppPackaging, UniversalPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,7 @@ lazy val otelExtension = (project in file("otel-extension"))
       "-Dotel.javaagent.testing.transform-safe-logging.enabled=true",
       "-Dotel.metrics.exporter=otlp",
       "-Dmesmer.akka.persistence.templated=false",
-
+      "-Dio.scalac.mesmer.test=true",
       // suppress repeated logging of "No metric data to export - skipping export."
       // since PeriodicMetricReader is configured with a short interval
       "-Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.io.opentelemetry.sdk.metrics.export.PeriodicMetricReader=INFO",

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val otelExtension = (project in file("otel-extension"))
     assembly / test            := {},
     assembly / assemblyJarName := s"${name.value}_${scalaBinaryVersion.value}-${version.value}-assembly.jar",
     assemblyMergeStrategySettings,
-    assembly / assemblyOption ~= { _.withIncludeScala(false) },
+    assembly / assemblyOption ~= { _.withIncludeScala(true) },
     assembly / artifact := {
       val art = (assembly / artifact).value
       art.withClassifier(Some("assembly"))
@@ -173,7 +173,7 @@ lazy val example = (project in file("example"))
     commands += runExampleWithOtelAgent,
     commands += runStreamExampleWithOtelAgent
   )
-  .dependsOn(extension)
+  .dependsOn(core)
 
 lazy val docs = project
   .in(file("mesmer-docs")) // important: it must not be docs/

--- a/example/src/main/resources/application.conf
+++ b/example/src/main/resources/application.conf
@@ -9,8 +9,6 @@ akka {
     serialization-bindings {
       "example.serialization.SerializableMessage" = jackson-cbor
     }
-
-    typed.extensions = ["io.scalac.mesmer.extension.AkkaMonitoring"]
   }
 
   coordinated-shutdown.exit-jvm = on
@@ -26,6 +24,7 @@ akka {
       auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
   }
+
   remote {
     artery {
       enabled = on

--- a/otel-extension/src/main/java/akka/stream/GraphStageIslandOtelAdvice.java
+++ b/otel-extension/src/main/java/akka/stream/GraphStageIslandOtelAdvice.java
@@ -1,20 +1,23 @@
 package akka.stream;
 
-import akka.stream.Attributes;
-import akka.stream.Shape;
 import akka.stream.impl.StreamLayout;
 import io.scalac.mesmer.otelextension.instrumentations.akka.stream.impl.GraphStageIslandOps;
-import net.bytebuddy.asm.Advice;
-
 import java.util.ArrayList;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 
 public class GraphStageIslandOtelAdvice {
 
   @Advice.OnMethodEnter
   public static void materializeAtomic(
-      @Advice.Argument(0) StreamLayout.AtomicModule<Shape, Object> mod,
-      @Advice.Argument(value = 1, readOnly = false) Attributes attributes,
+      @Advice.Argument(0) Object mod,
+      @Advice.Argument(value = 1, readOnly = false, typing = Assigner.Typing.DYNAMIC)
+          Object attributes,
       @Advice.FieldValue("logics") ArrayList<?> logics) {
-    attributes = GraphStageIslandOps.markLastSink(mod.shape(), attributes, logics.size());
+    attributes =
+        GraphStageIslandOps.markLastSink(
+            ((StreamLayout.AtomicModule<Shape, Object>) mod).shape(),
+            (Attributes) attributes,
+            logics.size());
   }
 }

--- a/otel-extension/src/main/java/io/scalac/mesmer/instrumentation/http/impl/OverridingRawPathMatcher.java
+++ b/otel-extension/src/main/java/io/scalac/mesmer/instrumentation/http/impl/OverridingRawPathMatcher.java
@@ -1,17 +1,18 @@
 package io.scalac.mesmer.instrumentation.http.impl;
 
-import akka.http.scaladsl.server.Directive;
 import akka.http.scaladsl.server.PathMatcher;
 import io.scalac.mesmer.otelextension.instrumentations.akka.http.OverridingRawPatchMatcherImpl;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 
 public class OverridingRawPathMatcher {
 
   @Advice.OnMethodExit
   public static void onExit(
-      @Advice.Argument(0) PathMatcher<?> matcher,
-      @Advice.Return(readOnly = false) Directive<?> result) {
+      @Advice.Argument(0) Object matcher,
+      @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Object result) {
+    //
 
-    result = OverridingRawPatchMatcherImpl.rawPathPrefix(matcher);
+    result = OverridingRawPatchMatcherImpl.rawPathPrefix((PathMatcher<?>) matcher);
   }
 }

--- a/otel-extension/src/main/java/io/scalac/mesmer/instrumentation/http/impl/OverridingRawPathMatcher.java
+++ b/otel-extension/src/main/java/io/scalac/mesmer/instrumentation/http/impl/OverridingRawPathMatcher.java
@@ -11,7 +11,6 @@ public class OverridingRawPathMatcher {
   public static void onExit(
       @Advice.Argument(0) Object matcher,
       @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Object result) {
-    //
 
     result = OverridingRawPatchMatcherImpl.rawPathPrefix((PathMatcher<?>) matcher);
   }

--- a/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaStreamInstrumentationModule.java
+++ b/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaStreamInstrumentationModule.java
@@ -3,6 +3,7 @@ package io.scalac.mesmer.otelextension.akka;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.tooling.muzzle.InstrumentationModuleMuzzle;
@@ -30,7 +31,11 @@ public class MesmerAkkaStreamInstrumentationModule extends InstrumentationModule
 
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    return hasClassesNamed("io.scalac.mesmer.extension.AkkaStreamMonitoring");
+    if (Config.get().getBoolean("io.scalac.mesmer.test", false)) {
+      return super.classLoaderMatcher();
+    } else {
+      return hasClassesNamed("io.scalac.mesmer.extension.AkkaStreamMonitoring");
+    }
   }
 
   @Override

--- a/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaStreamInstrumentationModule.java
+++ b/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaStreamInstrumentationModule.java
@@ -1,5 +1,7 @@
 package io.scalac.mesmer.otelextension.akka;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -11,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class MesmerAkkaStreamInstrumentationModule extends InstrumentationModule
@@ -23,6 +26,11 @@ public class MesmerAkkaStreamInstrumentationModule extends InstrumentationModule
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return AkkaStreamAgent.agent().asOtelTypeInstrumentations();
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("io.scalac.mesmer.extension.AkkaStreamMonitoring");
   }
 
   @Override

--- a/otel-extension/src/main/scala/akka/ActorGraphInterpreterProcessEventAdvice.scala
+++ b/otel-extension/src/main/scala/akka/ActorGraphInterpreterProcessEventAdvice.scala
@@ -9,9 +9,12 @@ import net.bytebuddy.asm.Advice
 object ActorGraphInterpreterProcessEventOtelAdvice {
 
   @Advice.OnMethodExit
-  def processEvent(@Advice.This self: AnyRef, @Advice.Argument(0) boundaryEvent: BoundaryEvent): Unit =
-    if (boundaryEvent.shell.isTerminated) {
-      ActorGraphInterpreterOtelDecorator.shellFinished(boundaryEvent.shell, self.asInstanceOf[Actor])
+  def processEvent(@Advice.This self: AnyRef, @Advice.Argument(0) boundaryEvent: Object): Unit =
+    if (boundaryEvent.asInstanceOf[BoundaryEvent].shell.isTerminated) {
+      ActorGraphInterpreterOtelDecorator.shellFinished(
+        boundaryEvent.asInstanceOf[BoundaryEvent].shell,
+        self.asInstanceOf[Actor]
+      )
     }
 
 }
@@ -25,11 +28,14 @@ object ActorGraphInterpreterTryInitOtelAdvice {
   @Advice.OnMethodExit
   def tryInit(
     @Advice.This self: AnyRef,
-    @Advice.Argument(0) shell: GraphInterpreterShellMirror,
+    @Advice.Argument(0) shell: Object,
     @Advice.Return initialized: Boolean
   ): Unit =
     if (!initialized) {
-      ActorGraphInterpreterOtelDecorator.shellFinished(shell, self.asInstanceOf[Actor])
+      ActorGraphInterpreterOtelDecorator.shellFinished(
+        shell.asInstanceOf[GraphInterpreterShellMirror],
+        self.asInstanceOf[Actor]
+      )
     }
 
 }

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/stream/impl/PhasedFusingActorMaterializerAdvice.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/stream/impl/PhasedFusingActorMaterializerAdvice.scala
@@ -12,7 +12,7 @@ import io.scalac.mesmer.core.model.Tag
 object PhasedFusingActorMaterializerAdvice {
 
   @OnMethodExit
-  def actorOf(@Return ref: ActorRef, @This self: Object): Unit =
+  def actorOf(@Return ref: Object, @This self: Object): Unit =
     EventBus(self.asInstanceOf[akka.MesmerMirrorTypes.ExtendedActorMaterializerMirror].system.toTyped)
-      .publishEvent(ActorEvent.TagsSet(ActorRefTags(ref, Set(Tag.stream))))
+      .publishEvent(ActorEvent.TagsSet(ActorRefTags(ref.asInstanceOf[ActorRef], Set(Tag.stream))))
 }


### PR DESCRIPTION

## Summary:

Make otelExtension jar slimmer (without any dependencies apart from scala classes) and add conditional apply of streams transformations. At this point we no longer require extension to be on the classpath for other instrumentation to work, althought `core` is still required 


