### PR TITLE
Fixed snapshot metric - it had a wrong name

### DIFF
--- a/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/persistence/OtelAkkaPersistenceAgentTest.scala
+++ b/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/persistence/OtelAkkaPersistenceAgentTest.scala
@@ -70,9 +70,9 @@ class OtelAkkaPersistenceAgentTest
       }
 
     assertMetrics("mesmer")(
-      "mesmer_akka_persistence_recovery_time" -> checkRecovery,
-      "mesmer_akka_persistence_event_time"    -> checkMetricEmpty,
-      "mesmer_akka_persistence_event_total"   -> checkMetricEmpty
+      "mesmer_akka_persistence_recovery_time"  -> checkRecovery,
+      "mesmer_akka_persistence_event_time"     -> checkMetricEmpty,
+      "mesmer_akka_persistence_snapshot_total" -> checkMetricEmpty
     )
   }
 
@@ -82,9 +82,9 @@ class OtelAkkaPersistenceAgentTest
     val check: MetricData => Unit = checkCount(id)(1)
 
     assertMetrics("mesmer")(
-      "mesmer_akka_persistence_recovery_time" -> check,
-      "mesmer_akka_persistence_event_time"    -> check,
-      "mesmer_akka_persistence_event_total"   -> check
+      "mesmer_akka_persistence_recovery_time"  -> check,
+      "mesmer_akka_persistence_event_time"     -> check,
+      "mesmer_akka_persistence_snapshot_total" -> check
     )
   }
 
@@ -95,9 +95,9 @@ class OtelAkkaPersistenceAgentTest
       def check(num: Int) = checkCount(id)(num)
 
       assertMetrics("mesmer")(
-        "mesmer_akka_persistence_recovery_time" -> check(1),
-        "mesmer_akka_persistence_event_time"    -> check(5),
-        "mesmer_akka_persistence_event_total"   -> check(5)
+        "mesmer_akka_persistence_recovery_time"  -> check(1),
+        "mesmer_akka_persistence_event_time"     -> check(5),
+        "mesmer_akka_persistence_snapshot_total" -> check(5)
       )
   }
 

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/persistence/Instruments.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/persistence/Instruments.scala
@@ -38,7 +38,7 @@ object InstrumentsProvider {
 
         val snapshots: LongCounter = provider
           .get("mesmer")
-          .counterBuilder("mesmer_akka_persistence_event_total")
+          .counterBuilder("mesmer_akka_persistence_snapshot_total")
           .build()
       })
     } else _instance


### PR DESCRIPTION
Closes #xxx 
___

## Summary:

Fixes the incorrect metric name


