### PR TITLE
Reinstate actors created metric

### DIFF
--- a/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/actor/otel/ActorMailboxTest.scala
+++ b/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/actor/otel/ActorMailboxTest.scala
@@ -6,7 +6,6 @@ import akka.actor.{ ActorSystem, PoisonPill }
 import akka.dispatch.{ BoundedPriorityMailbox, BoundedStablePriorityMailbox, Envelope }
 import com.typesafe.config.{ Config, ConfigFactory }
 import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.sdk.metrics.data.MetricDataType
 import io.scalac.mesmer.agent.utils.{ OtelAgentTest, SafeLoadSystem }
 import io.scalac.mesmer.core.akka.model.AttributeNames
 import io.scalac.mesmer.core.config.MesmerPatienceConfig

--- a/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/actor/otel/ActorMailboxTest.scala
+++ b/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/actor/otel/ActorMailboxTest.scala
@@ -128,7 +128,7 @@ class ActorMailboxTest
       props
     )
 
-    assertMetric("mesmer_akka_dropped_total") { data =>
+    assertMetric("mesmer_akka_actor_dropped_messages_total") { data =>
       val points = data.getLongSumData.getPoints.asScala
         .filter(point =>
           Option(point.getAttributes.get(AttributeKey.stringKey(AttributeNames.ActorPath)))

--- a/otel-extension/src/main/java/akka/actor/impl/LocalActorRefProviderAdvice.java
+++ b/otel-extension/src/main/java/akka/actor/impl/LocalActorRefProviderAdvice.java
@@ -1,0 +1,12 @@
+package akka.actor.impl;
+
+import io.scalac.mesmer.otelextension.instrumentations.akka.actor.InstrumentsProvider;
+import net.bytebuddy.asm.Advice;
+
+public class LocalActorRefProviderAdvice {
+
+  @Advice.OnMethodExit
+  public static void actorOfExit() {
+    InstrumentsProvider.instance().actorsCreated().add(1);
+  }
+}

--- a/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaActorInstrumentationModule.java
+++ b/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaActorInstrumentationModule.java
@@ -35,7 +35,8 @@ public class MesmerAkkaActorInstrumentationModule extends InstrumentationModule
         AkkaActorAgent.boundedQueueBasedMessageQueueConstructorAdvice(),
         AkkaActorAgent.boundedQueueBasedMessageQueueQueueAdvice(),
         AkkaActorAgent.boundedMessageQueueSemanticsEnqueueAdvice(),
-        AkkaActorAgent.actorCellReceived());
+        AkkaActorAgent.actorCellReceived(),
+        AkkaActorAgent.actorCreatedAdvice());
   }
 
   @Override

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/AkkaActorAgent.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/AkkaActorAgent.scala
@@ -150,4 +150,10 @@ object AkkaActorAgent {
     )
   )
 
+  val actorCreatedAdvice: TypeInstrumentation = Instrumentation(
+    matchers.named("akka.actor.LocalActorRefProvider")
+  ).`with`(
+    Advice(named("actorOf"), "akka.actor.impl.LocalActorRefProviderAdvice")
+  )
+
 }

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/Instruments.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/Instruments.scala
@@ -26,39 +26,39 @@ object Instruments {
 
     lazy val failedMessages: LongCounter = provider
       .get("mesmer")
-      .counterBuilder("mesmer_akka_failed_messages_total")
+      .counterBuilder("mesmer_akka_actor_failed_messages_total")
       .build()
 
     lazy val processingTime: LongHistogram = provider
       .get("mesmer")
-      .histogramBuilder("mesmer_akka_message_processing_time")
+      .histogramBuilder("mesmer_akka_actor_message_processing_time")
       .ofLongs()
       .build()
 
     lazy val unhandledMessages: LongCounter = provider
       .get("mesmer")
-      .counterBuilder("mesmer_akka_unhandled_messages_total")
+      .counterBuilder("mesmer_akka_actor_unhandled_messages_total")
       .build()
 
     lazy val droppedMessages: LongCounter = provider
       .get("mesmer")
-      .counterBuilder("mesmer_akka_dropped_total")
+      .counterBuilder("mesmer_akka_actor_dropped_messages_total")
       .build()
 
     lazy val mailboxTime: LongHistogram = provider
       .get("mesmer")
-      .histogramBuilder("mesmer_akka_mailbox_time")
+      .histogramBuilder("mesmer_akka_actor_mailbox_time")
       .ofLongs()
       .build()
 
     lazy val stashedMessages: LongCounter = provider
       .get("mesmer")
-      .counterBuilder("mesmer_akka_stashed_messages_total")
+      .counterBuilder("mesmer_akka_actor_stashed_messages_total")
       .build()
 
     lazy val sentMessages: LongCounter = provider
       .get("mesmer")
-      .counterBuilder("mesmer_akka_sent_messages_total")
+      .counterBuilder("mesmer_akka_actor_sent_messages_total")
       .build()
   }
 }

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/Instruments.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/Instruments.scala
@@ -19,6 +19,8 @@ trait Instruments {
   def stashedMessages: LongCounter
 
   def sentMessages: LongCounter
+
+  def actorsCreated: LongCounter
 }
 
 object Instruments {
@@ -59,6 +61,11 @@ object Instruments {
     lazy val sentMessages: LongCounter = provider
       .get("mesmer")
       .counterBuilder("mesmer_akka_actor_sent_messages_total")
+      .build()
+
+    lazy val actorsCreated: LongCounter = provider
+      .get("mesmer")
+      .counterBuilder("mesmer_akka_actor_actors_created_total")
       .build()
   }
 }


### PR DESCRIPTION
Closes #xxx 
___

## Summary:

Reinstates Actors Created metric but without using the akka extension


