### PR TITLE
Move node_down cluster metric to otel extension

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val example = (project in file("example"))
     commands += runStreamExampleWithOtelAgent,
     commands += runZioExampleWithOtelAgent
   )
-  .dependsOn(core, extension)
+  .dependsOn(core)
 
 lazy val docs = project
   .in(file("mesmer-docs")) // important: it must not be docs/

--- a/core/src/main/scala/io/scalac/mesmer/core/util/Retry.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/util/Retry.scala
@@ -25,6 +25,9 @@ object Retry {
       retry(n, pause)(fn)
     } else {
       Thread.sleep(pause.toMillis)
-      retryWithPrecondition(n - 1, pause)(precondition)(fn)
+      if (n > 0) { retryWithPrecondition(n - 1, pause)(precondition)(fn) }
+      else {
+        Failure(new RuntimeException(s"Precondition failed - couldn't retry."))
+      }
     }
 }

--- a/core/src/main/scala/io/scalac/mesmer/core/util/Retry.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/util/Retry.scala
@@ -7,12 +7,24 @@ import scala.util.Try
 
 object Retry {
   @annotation.tailrec
-  def retryWithPauses[T](n: Int, pause: FiniteDuration)(fn: => T): Try[T] =
+  def retry[T](n: Int, pause: FiniteDuration)(fn: => T): Try[T] =
     Try(fn) match {
       case Success(value) => Success(value)
       case Failure(_) if n > 1 =>
         Thread.sleep(pause.toMillis)
-        retryWithPauses(n - 1, pause)(fn)
+        retry(n - 1, pause)(fn)
       case Failure(exception) => Failure(exception)
+    }
+
+  /**
+   * Same as retry but adds an additional precondition check, eg. waiting for another extension to register.
+   */
+  @annotation.tailrec
+  def retryWithPrecondition[T](n: Int, pause: FiniteDuration)(precondition: => Boolean)(fn: => T): Try[T] =
+    if (precondition) {
+      retry(n, pause)(fn)
+    } else {
+      Thread.sleep(pause.toMillis)
+      retryWithPrecondition(n - 1, pause)(precondition)(fn)
     }
 }

--- a/core/src/test/scala/io/scalac/mesmer/core/util/RetryTest.scala
+++ b/core/src/test/scala/io/scalac/mesmer/core/util/RetryTest.scala
@@ -37,4 +37,27 @@ class RetryTest extends AnyFlatSpec with Matchers {
       }
     Retry.retry(3, 1.millisecond)(function()) should be(Success(1))
   }
+
+  it should "fail when the precondition never succeeds" in {
+    val result = Retry.retryWithPrecondition(3, 1.millisecond)(false)(1)
+
+    result shouldBe a[Failure[RuntimeException]]
+  }
+
+  it should "succeed after several trials" in {
+    var preconditionResults = List(false, false, true)
+
+    def precondition(): Boolean = {
+      val currentResult = preconditionResults.head
+      preconditionResults = preconditionResults.tail
+      currentResult
+    }
+
+    Retry.retryWithPrecondition(3, 1.millisecond)(precondition())(1) shouldBe Success(1)
+  }
+
+  it should "still fail when precondition is true but error occurs" in {
+    def function(): Int = throw new RuntimeException("fail")
+    Retry.retryWithPrecondition(1, 1.millisecond)(true)(function()) shouldBe a[Failure[RuntimeException]]
+  }
 }

--- a/core/src/test/scala/io/scalac/mesmer/core/util/RetryTest.scala
+++ b/core/src/test/scala/io/scalac/mesmer/core/util/RetryTest.scala
@@ -17,13 +17,13 @@ class RetryTest extends AnyFlatSpec with Matchers {
       throw exception
     }
 
-    Retry.retryWithPauses(3, 1.millisecond)(function()) should be(Failure(exception))
+    Retry.retry(3, 1.millisecond)(function()) should be(Failure(exception))
     counter should be(3)
   }
 
   it should "succeed" in {
     def function(): Unit = ()
-    Retry.retryWithPauses(Int.MaxValue, 1.millisecond)(function()) should be(Success(()))
+    Retry.retry(Int.MaxValue, 1.millisecond)(function()) should be(Success(()))
   }
 
   it should "succeed the second time" in {
@@ -35,6 +35,6 @@ class RetryTest extends AnyFlatSpec with Matchers {
       } else {
         counter
       }
-    Retry.retryWithPauses(3, 1.millisecond)(function()) should be(Success(1))
+    Retry.retry(3, 1.millisecond)(function()) should be(Success(1))
   }
 }

--- a/example/src/main/resources/application.conf
+++ b/example/src/main/resources/application.conf
@@ -10,7 +10,7 @@ akka {
       "example.serialization.SerializableMessage" = jackson-cbor
     }
 
-    typed.extensions = ["io.scalac.mesmer.extension.AkkaMonitoring"]
+    //typed.extensions = ["io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtensionId"]
   }
 
   coordinated-shutdown.exit-jvm = on

--- a/example/src/main/resources/application.conf
+++ b/example/src/main/resources/application.conf
@@ -9,8 +9,6 @@ akka {
     serialization-bindings {
       "example.serialization.SerializableMessage" = jackson-cbor
     }
-
-    //typed.extensions = ["io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtensionId"]
   }
 
   coordinated-shutdown.exit-jvm = on

--- a/example/src/main/resources/local.conf
+++ b/example/src/main/resources/local.conf
@@ -7,8 +7,6 @@ akka {
     serialization-bindings {
       "example.serialization.SerializableMessage" = jackson-cbor
     }
-
-    typed.extensions = ["io.scalac.mesmer.extension.AkkaMonitoring"]
   }
 
 }

--- a/example/src/main/scala/example/Boot.scala
+++ b/example/src/main/scala/example/Boot.scala
@@ -50,10 +50,6 @@ object Boot extends App with FailFastCirceSupport with JsonCodecs {
     val host       = config.getString("app.host")
     val port       = config.getInt("app.port")
 
-    // this is important to initialize metric exporting before actor system when starting mesmer from configuration
-    // mesmer on initialization gets hook to OTel metricProvider and if it's not initialized before it defaults to noop
-    logger.info("Starting metric exporter")
-
     implicit val system: ActorSystem[Nothing] =
       ActorSystem[Nothing](Behaviors.empty, systemName, config)
 

--- a/example/src/main/scala/example/Boot.scala
+++ b/example/src/main/scala/example/Boot.scala
@@ -89,5 +89,6 @@ object Boot extends App with FailFastCirceSupport with JsonCodecs {
         .onComplete(_ => system.terminate())
     }
   }
+
   startUp()
 }

--- a/extension/src/main/scala/io/scalac/mesmer/extension/OnClusterStartUp.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/OnClusterStartUp.scala
@@ -30,10 +30,10 @@ object OnClusterStartUp {
           Behaviors.withStash(1024) { stash =>
             Behaviors.receiveMessage {
               case Timeout =>
-                ctx.log.warn("Initialization timed out")
+                ctx.log.warn("Cluster initialization timed out.")
                 Behaviors.stopped
               case Initialized(_) =>
-                ctx.log.info("Cluster initialized")
+                ctx.log.info("Cluster initialized.")
                 timer.cancel(timeoutTimerKey)
                 val selfMember = Cluster(ctx.system).selfMember
                 stash.unstashAll(inner(selfMember).asInstanceOf[Behavior[Any]])

--- a/otel-extension/src/it/resources/application-test.conf
+++ b/otel-extension/src/it/resources/application-test.conf
@@ -6,9 +6,6 @@ akka {
     snapshot-store.plugin = "akka.persistence.snapshot-store.local"
     snapshot-store.local.dir = "target/snapshot"
   }
-  actor {
-
-  }
 }
 
 io.scalac.mesmer.actor.rules {

--- a/otel-extension/src/it/resources/cluster-application-test.conf
+++ b/otel-extension/src/it/resources/cluster-application-test.conf
@@ -1,0 +1,31 @@
+akka {
+  loglevel = DEBUG
+
+  persistence {
+    journal.plugin = "akka.persistence.journal.inmem"
+    snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+    snapshot-store.local.dir = "target/snapshot"
+  }
+  actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
+  }
+  remote.artery {
+      canonical {
+        hostname = "127.0.0.1"
+        port = 2551
+      }
+    }
+  cluster {
+    seed-nodes = [
+      "akka://test-system@127.0.0.1:2551"
+    ]
+  }
+}
+
+io.scalac.mesmer.actor.rules {
+  "/**" = instance
+}
+
+io.scalac.akka-monitoring.boot.backend = false
+
+akka.stream.materializer.creation-timeout = 10 minutes

--- a/otel-extension/src/it/scala/io/scalac/mesmer/agent/utils/OtelAgentTest.scala
+++ b/otel-extension/src/it/scala/io/scalac/mesmer/agent/utils/OtelAgentTest.scala
@@ -1,11 +1,8 @@
 package io.scalac.mesmer.agent.utils
 
 import io.opentelemetry.instrumentation.testing.AgentTestRunner
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo
 import io.opentelemetry.sdk.metrics.data.{ HistogramPointData, MetricData }
 import io.opentelemetry.sdk.metrics.internal.aggregator.EmptyMetricData
-import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData
-import io.opentelemetry.sdk.resources.Resource
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, OptionValues, TestSuite }
 

--- a/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/cluster/AkkaClusterTest.scala
+++ b/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/cluster/AkkaClusterTest.scala
@@ -1,0 +1,32 @@
+package io.scalac.mesmer.instrumentation.akka.cluster
+
+import akka.actor.ActorSystem
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.cluster.typed.Cluster
+import com.typesafe.config.ConfigFactory
+import io.scalac.mesmer.agent.utils.OtelAgentTest
+import io.scalac.mesmer.core.util.TestOps
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Seconds, Span }
+
+import scala.jdk.CollectionConverters._
+
+final class AkkaClusterTest extends AnyFlatSpec with OtelAgentTest with TestOps with Matchers with BeforeAndAfterEach {
+
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(1, Seconds)))
+
+  override protected def beforeEach(): Unit = super.beforeEach()
+
+  it should "record nodes down metric" in {
+    val system = ActorSystem("test-system", ConfigFactory.load("cluster-application-test")).toTyped
+    Cluster(system)
+
+    assertMetric("mesmer_akka_cluster_node_down_total") { data =>
+      val totalCount = data.getLongSumData.getPoints.asScala.map(_.getValue).sum
+      totalCount should be >= 0L
+    }
+  }
+}

--- a/otel-extension/src/main/java/akka/cluster/impl/ClusterMetricsExtensionAdvice.java
+++ b/otel-extension/src/main/java/akka/cluster/impl/ClusterMetricsExtensionAdvice.java
@@ -7,7 +7,7 @@ import net.bytebuddy.asm.Advice;
 public class ClusterMetricsExtensionAdvice {
 
   @Advice.OnMethodExit
-  public static void init(@Advice.This ActorSystem classicSystem) throws InterruptedException {
+  public static void init(@Advice.This ActorSystem classicSystem) {
     AkkaClusterMonitorExtension.registerExtension(classicSystem);
   }
 }

--- a/otel-extension/src/main/java/akka/cluster/impl/ClusterMetricsExtensionAdvice.java
+++ b/otel-extension/src/main/java/akka/cluster/impl/ClusterMetricsExtensionAdvice.java
@@ -1,0 +1,13 @@
+package akka.cluster.impl;
+
+import akka.actor.ActorSystem;
+import io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtension;
+import net.bytebuddy.asm.Advice;
+
+public class ClusterMetricsExtensionAdvice {
+
+  @Advice.OnMethodExit
+  public static void init(@Advice.This ActorSystem classicSystem) throws InterruptedException {
+    AkkaClusterMonitorExtension.registerExtension(classicSystem);
+  }
+}

--- a/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaClusterInstrumentationModule.java
+++ b/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaClusterInstrumentationModule.java
@@ -45,7 +45,9 @@ public class MesmerAkkaClusterInstrumentationModule extends InstrumentationModul
         "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtension$$anon$1",
         "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtensionId$",
         "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.ClusterEventsMonitor$",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.ClusterEventsMonitor$MemberEventWrapper",
         "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.OnClusterStartup$",
-        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.OnClusterStartup$Initialized");
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.OnClusterStartup$Initialized",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.OnClusterStartup$Timeout$");
   }
 }

--- a/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaClusterInstrumentationModule.java
+++ b/otel-extension/src/main/java/io/scalac/mesmer/otelextension/akka/MesmerAkkaClusterInstrumentationModule.java
@@ -1,0 +1,51 @@
+package io.scalac.mesmer.otelextension.akka;
+
+import static java.util.Collections.emptyList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.tooling.muzzle.InstrumentationModuleMuzzle;
+import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappingsBuilder;
+import io.opentelemetry.javaagent.tooling.muzzle.references.ClassRef;
+import io.scalac.mesmer.otelextension.instrumentations.akka.cluster.AkkaClusterAgent;
+import java.util.List;
+import java.util.Map;
+
+@AutoService(InstrumentationModule.class)
+public class MesmerAkkaClusterInstrumentationModule extends InstrumentationModule
+    implements InstrumentationModuleMuzzle {
+  public MesmerAkkaClusterInstrumentationModule() {
+    super("mesmer-akka-cluster");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return List.of(AkkaClusterAgent.clusterMetricsExtension());
+  }
+
+  @Override
+  public Map<String, ClassRef> getMuzzleReferences() {
+    return java.util.Collections.emptyMap();
+  }
+
+  @Override
+  public void registerMuzzleVirtualFields(VirtualFieldMappingsBuilder builder) {}
+
+  @Override
+  public List<String> getMuzzleHelperClassNames() {
+    return emptyList();
+  }
+
+  @Override
+  public List<String> getAdditionalHelperClassNames() {
+    return List.of(
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtension",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtension$",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtension$$anon$1",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.AkkaClusterMonitorExtensionId$",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.ClusterEventsMonitor$",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.OnClusterStartup$",
+        "io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension.OnClusterStartup$Initialized");
+  }
+}

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/extension/ActorLifecycleMonitorExtension.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/actor/extension/ActorLifecycleMonitorExtension.scala
@@ -11,7 +11,11 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
 
-import io.scalac.mesmer.core.util.Retry
+import io.scalac.mesmer.core.util.Retry._
+
+class ActorLifecycleMonitorExtension(actorSystem: ActorSystem[_]) extends Extension {
+  ActorLifecycleMonitor.subscribeToEventStream(actorSystem)
+}
 
 object ActorLifecycleMonitorExtension {
 
@@ -20,7 +24,7 @@ object ActorLifecycleMonitorExtension {
   def registerExtension(system: akka.actor.ActorSystem): Unit =
     new Thread(new Runnable() {
       override def run(): Unit =
-        Retry.retryWithPauses(10, 2.seconds)(register(system)) match {
+        retry(10, 2.seconds)(register(system)) match {
           case Failure(error) =>
             log.error(s"Failed to install the Actor Lifecycle Monitoring Extension. Reason: $error")
           case Success(_) => log.info("Successfully installed the Actor Lifecycle Monitoring Extension.")
@@ -29,10 +33,6 @@ object ActorLifecycleMonitorExtension {
 
   private def register(system: actor.ActorSystem) =
     system.toTyped.registerExtension(ActorLifecycleMonitorExtensionId)
-}
-
-class ActorLifecycleMonitorExtension(actorSystem: ActorSystem[_]) extends Extension {
-  ActorLifecycleMonitor.subscribeToEventStream(actorSystem)
 }
 
 object ActorLifecycleMonitorExtensionId extends ExtensionId[ActorLifecycleMonitorExtension] {

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/AkkaClusterAgent.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/AkkaClusterAgent.scala
@@ -1,0 +1,15 @@
+package io.scalac.mesmer.otelextension.instrumentations.akka.cluster
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation
+
+import io.scalac.mesmer.agent.util.dsl.matchers.isConstructor
+import io.scalac.mesmer.agent.util.dsl.matchers.named
+import io.scalac.mesmer.agent.util.i13n.Advice
+import io.scalac.mesmer.agent.util.i13n.Instrumentation
+
+object AkkaClusterAgent {
+
+  val clusterMetricsExtension: TypeInstrumentation =
+    Instrumentation(named("akka.actor.ActorSystemImpl"))
+      .`with`(Advice(isConstructor, "akka.cluster.impl.ClusterMetricsExtensionAdvice"))
+}

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/AkkaClusterMonitorExtension.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/AkkaClusterMonitorExtension.scala
@@ -1,0 +1,78 @@
+package io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension
+
+import akka.actor
+import akka.actor.ExtendedActorSystem
+import akka.actor.typed._
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.cluster.typed.Cluster
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.duration.DurationInt
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import io.scalac.mesmer.core.AkkaDispatcher
+import io.scalac.mesmer.core.util.Retry
+
+class AkkaClusterMonitorExtension(actorSystem: ActorSystem[_]) extends Extension {
+
+  private val log = LoggerFactory.getLogger(classOf[AkkaClusterMonitorExtension])
+
+  private val name = "mesmerClusterEventsMonitor"
+
+  private val dispatcher: DispatcherSelector = AkkaDispatcher.safeDispatcherSelector(actorSystem)
+
+  checkPreconditions(actorSystem) match {
+    case Left(initializationError) => log.error(s"$name Initialization error occurred: $initializationError")
+    case Right(_)                  => startActor()
+  }
+
+  private def checkPreconditions(actorSystem: ActorSystem[_]): Either[String, Unit] = for {
+    _ <- reflectiveIsInstanceOf("akka.actor.typed.internal.adapter.ActorSystemAdapter", actorSystem)
+    classic = actorSystem.classicSystem.asInstanceOf[ExtendedActorSystem]
+    _ <- reflectiveIsInstanceOf("akka.cluster.ClusterActorRefProvider", classic.provider)
+  } yield ()
+
+  private def startActor(): ActorRef[ClusterEventsMonitor.MemberEventWrapper] =
+    actorSystem.systemActorOf(
+      Behaviors
+        .supervise(ClusterEventsMonitor())
+        .onFailure[Exception](SupervisorStrategy.restart),
+      name,
+      dispatcher
+    )
+
+  private def reflectiveIsInstanceOf(className: String, ref: Any): Either[String, Unit] =
+    Try(Class.forName(className)).toEither.left.map {
+      case _: ClassNotFoundException => s"Class $className not found"
+      case e                         => e.getMessage
+    }.filterOrElse(_.isInstance(ref), s"Ref $ref is not instance of $className").map(_ => ())
+
+}
+
+object AkkaClusterMonitorExtension {
+
+  private val log = LoggerFactory.getLogger(classOf[AkkaClusterMonitorExtension])
+
+  def registerExtension(system: akka.actor.ActorSystem): Unit =
+    new Thread(new Runnable() {
+      override def run(): Unit = {
+        println(s"register extension ${Thread.currentThread().getName}")
+        Retry.retryWithPrecondition(10, 2.seconds)(system.toTyped.hasExtension(Cluster))(register(system))
+      } match {
+        case Failure(error) =>
+          log.error(s"Failed to install the Akka Cluster Monitoring Extension. Reason: $error")
+        case Success(_) => log.info("Successfully installed the Akka Cluster Monitoring Extension.")
+      }
+    })
+      .start()
+
+  private def register(system: actor.ActorSystem) = system.toTyped.registerExtension(AkkaClusterMonitorExtensionId)
+}
+
+object AkkaClusterMonitorExtensionId extends ExtensionId[AkkaClusterMonitorExtension] {
+  override def createExtension(system: ActorSystem[_]): AkkaClusterMonitorExtension =
+    new AkkaClusterMonitorExtension(system)
+}

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/AkkaClusterMonitorExtension.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/AkkaClusterMonitorExtension.scala
@@ -58,14 +58,13 @@ object AkkaClusterMonitorExtension {
 
   def registerExtension(system: akka.actor.ActorSystem): Unit =
     new Thread(new Runnable() {
-      override def run(): Unit = {
-        println(s"register extension ${Thread.currentThread().getName}")
-        Retry.retryWithPrecondition(10, 2.seconds)(system.toTyped.hasExtension(Cluster))(register(system))
-      } match {
-        case Failure(error) =>
-          log.error(s"Failed to install the Akka Cluster Monitoring Extension. Reason: $error")
-        case Success(_) => log.info("Successfully installed the Akka Cluster Monitoring Extension.")
-      }
+      override def run(): Unit =
+        Retry.retryWithPrecondition(10, 2.seconds)(system.toTyped.hasExtension(Cluster))(register(system)) match {
+          case Failure(error) =>
+            log.error(s"Failed to install the Akka Cluster Monitoring Extension. Reason: $error")
+          case Success(_) =>
+            log.info("Successfully installed the Akka Cluster Monitoring Extension.")
+        }
     })
       .start()
 

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/ClusterEventsMonitor.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/ClusterEventsMonitor.scala
@@ -1,0 +1,50 @@
+package io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.ClusterEvent.MemberDowned
+import akka.cluster.ClusterEvent.MemberEvent
+import akka.cluster.typed.Cluster
+import akka.cluster.typed.Subscribe
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.Meter
+
+import io.scalac.mesmer.core.model.AkkaNodeOps
+
+object ClusterEventsMonitor {
+
+  final case class MemberEventWrapper(event: MemberEvent)
+
+  private val meter: Meter = GlobalOpenTelemetry.getMeter("mesmer")
+
+  private val nodesDownCounter: LongCounter = meter
+    .counterBuilder("akka_cluster_node_down_total")
+    .setDescription("Counter for node down events")
+    .build()
+
+  def apply(): Behavior[MemberEventWrapper] =
+    OnClusterStartup { selfMember =>
+      Behaviors.setup { context =>
+        val reachabilityAdapter = context.messageAdapter[MemberEvent](MemberEventWrapper.apply)
+
+        Cluster(context.system).subscriptions ! Subscribe(
+          reachabilityAdapter,
+          classOf[MemberEvent]
+        )
+
+        val attributes: Attributes = Attributes.builder().put("node", selfMember.uniqueAddress.toNode).build()
+        nodesDownCounter.add(0L, attributes)
+
+        Behaviors.receiveMessage { case MemberEventWrapper(event) =>
+          event match {
+            case MemberDowned(_) =>
+              nodesDownCounter.add(1L, attributes)
+            case _ =>
+          }
+          Behaviors.same
+        }
+      }
+    }
+}

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/ClusterEventsMonitor.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/ClusterEventsMonitor.scala
@@ -20,7 +20,7 @@ object ClusterEventsMonitor {
   private val meter: Meter = GlobalOpenTelemetry.getMeter("mesmer")
 
   private val nodesDownCounter: LongCounter = meter
-    .counterBuilder("akka_cluster_node_down_total")
+    .counterBuilder("mesmer_akka_cluster_node_down_total")
     .setDescription("Counter for node down events")
     .build()
 

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/OnClusterStartup.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/OnClusterStartup.scala
@@ -7,10 +7,13 @@ import akka.cluster.Member
 import akka.cluster.typed.Cluster
 import akka.cluster.typed.SelfUp
 import akka.cluster.typed.Subscribe
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.FiniteDuration
 
 object OnClusterStartup {
+
+  private val log = LoggerFactory.getLogger(OnClusterStartup.getClass)
 
   private case class Initialized(currentClusterState: CurrentClusterState)
 
@@ -32,10 +35,10 @@ object OnClusterStartup {
           Behaviors.withStash(1024) { stash =>
             Behaviors.receiveMessage {
               case Timeout =>
-                // ctx.log.warn("Initialization timed out")
+                log.warn("Initialization timed out")
                 Behaviors.stopped
               case Initialized(_) =>
-                // ctx.log.info("Cluster initialized")
+                log.info("Cluster initialized")
                 timer.cancel(timeoutTimerKey)
                 val selfMember = Cluster(ctx.system).selfMember
                 stash.unstashAll(inner(selfMember).asInstanceOf[Behavior[Any]])

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/OnClusterStartup.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/akka/cluster/extension/OnClusterStartup.scala
@@ -1,0 +1,56 @@
+package io.scalac.mesmer.otelextension.instrumentations.akka.cluster.extension
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.Member
+import akka.cluster.typed.Cluster
+import akka.cluster.typed.SelfUp
+import akka.cluster.typed.Subscribe
+
+import scala.concurrent.duration.FiniteDuration
+
+object OnClusterStartup {
+
+  private case class Initialized(currentClusterState: CurrentClusterState)
+
+  private case object Timeout
+
+  private val timeoutTimerKey = "WithTimeoutKey"
+
+  def upTo[T](timeout: FiniteDuration)(inner: Member => Behavior[T]): Behavior[T] =
+    internalApply(inner, Some(timeout))
+
+  def apply[T](inner: Member => Behavior[T]): Behavior[T] =
+    internalApply(inner, None)
+
+  def internalApply[T](inner: Member => Behavior[T], timeout: Option[FiniteDuration]): Behavior[T] =
+    Behaviors
+      .setup[Any] { ctx =>
+        def init: Behavior[Any] = Behaviors.withTimers { timer =>
+          timeout.foreach(timeoutDuration => timer.startSingleTimer(timeoutTimerKey, Timeout, timeoutDuration))
+          Behaviors.withStash(1024) { stash =>
+            Behaviors.receiveMessage {
+              case Timeout =>
+                // ctx.log.warn("Initialization timed out")
+                Behaviors.stopped
+              case Initialized(_) =>
+                // ctx.log.info("Cluster initialized")
+                timer.cancel(timeoutTimerKey)
+                val selfMember = Cluster(ctx.system).selfMember
+                stash.unstashAll(inner(selfMember).asInstanceOf[Behavior[Any]])
+              case message: T @unchecked =>
+                stash.stash(message)
+                Behaviors.same
+              case _ => Behaviors.unhandled
+            }
+          }
+        }
+
+        val adapter = ctx.messageAdapter[SelfUp](selfUp => Initialized(selfUp.currentClusterState))
+        Cluster(ctx.system).subscriptions ! Subscribe(adapter, classOf[SelfUp])
+        init
+      }
+      .narrow[T]
+
+}

--- a/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/zio/advice/ZIOMetricsTaggedAdvice.scala
+++ b/otel-extension/src/main/scala/io/scalac/mesmer/otelextension/instrumentations/zio/advice/ZIOMetricsTaggedAdvice.scala
@@ -23,8 +23,6 @@ object ZIOMetricsTaggedAdvice {
       .find(classOf[Metric[Type, _, _]], classOf[String])
       .get(oldMetric)
 
-    println(name)
-
     val attributesSoFar: Option[Attributes] = Option(
       VirtualField
         .find(classOf[Metric[Type, _, _]], classOf[Attributes])


### PR DESCRIPTION
Closes #498
___

## Summary:

- reinstates node_down cluster metric
- adds a regression test so that we know when the metric disappears again


