### PR TITLE
Adjust test timings to be less sensitive

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,6 @@ lazy val otelExtension = (project in file("otel-extension"))
       "-Dotel.metric.export.interval=50", // 100 ms so that the "eventually" assertions could catch up
       "-Dotel.javaagent.testing.fail-on-context-leak=true",
       "-Dotel.javaagent.testing.transform-safe-logging.enabled=true",
-      "-Dotel.metrics.exporter=otlp",
       "-Dmesmer.akka.persistence.templated=false",
 
       // suppress repeated logging of "No metric data to export - skipping export."

--- a/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/stream/AkkaStreamsTest.scala
+++ b/otel-extension/src/it/scala/io/scalac/mesmer/instrumentation/akka/stream/AkkaStreamsTest.scala
@@ -70,12 +70,11 @@ class AkkaStreamsTest
   final class ActorStreamRefService(implicit system: ActorSystem[_]) {
     private val probe = TestProbe[ActorRef]("stream_refs")
 
-    def actors(number: Int): Seq[ActorRef] = probe
-      .within(2.seconds) {
-        val messages = probe.receiveMessages(number)
-        probe.expectNoMessage(probe.remaining)
-        messages
-      }
+    def actors(number: Int): Seq[ActorRef] = {
+      val messages = probe.receiveMessages(number, patienceConfig.timeout)
+      probe.expectNoMessage(2.seconds)
+      messages
+    }
 
     sealed trait Command
 


### PR DESCRIPTION
## Summary:

Hopefully these changes should be enough to fix flakiness on Windows CI machines.
