### PR TITLE
Change documentation links color

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -19,11 +19,11 @@
   --ifm-font-color-base-inverse: #121212; /* hero text color */
 
   --ifm-breadcrumb-color-active: #e10b53;
-  --ifm-navbar-link-hover-color: #e10b53;
+  --ifm-navbar-link-hover-color: #1b89c7;
   --ifm-menu-color-active: #e10b53;
 
   --ifm-background-color: #fcf4f2;
-  --ifm-link-color: #121212;
+  --ifm-link-color: #1b89c7;
 
   --ifm-pagination-nav-color-hover: #e10b53;
 }


### PR DESCRIPTION
## Summary:

At the moment the links shares the style with general text and cannot be distinguished. This commit changes the links color to the variation of blue.

<img width="792" alt="Screenshot 2023-03-06 at 14 28 33" src="https://user-images.githubusercontent.com/6901397/223123500-97fe9c32-d675-477b-8f10-39fb4a96d3f0.png">
