### PR TITLE
Setup scalafmt check for sbt project files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ inThisBuild(
   )
 )
 
-addCommandAlias("fmt", "scalafmtAll; scalafixAll")
-addCommandAlias("check", "scalafixAll --check; scalafmtCheckAll")
+addCommandAlias("fmt", "scalafmtSbt; scalafmtAll; scalafixAll")
+addCommandAlias("check", "scalafixAll --check; scalafmtCheckAll; scalafmtSbtCheck")
 addCommandAlias("testAll", "test; IntegrationTest/test")
 
 val projectRootDir = all.base.absolutePath


### PR DESCRIPTION
`scalafmtCheckAll`  does not check sbt project files, `scalafmtSbtCheck` is needed for that.